### PR TITLE
Dev

### DIFF
--- a/scorpio/__init__.py
+++ b/scorpio/__init__.py
@@ -1,2 +1,2 @@
 _program = "scorpio"
-__version__ = "0.3.7"
+__version__ = "0.3.8"

--- a/scorpio/__main__.py
+++ b/scorpio/__main__.py
@@ -47,6 +47,8 @@ def main(sysargs = sys.argv[1:]):
     constellation_group.add_argument('--pangolin', dest='pangolin', action='store_true',
                                     help='Uses `mrca_lineage` as label and excludes constellations/data directory for'
                                          ' robustness')
+    constellation_group.add_argument("--mutations", dest="mutations", required=False, nargs='+',
+                                     help="Extra mutations to type")
 
     misc_group = common.add_argument_group('Misc options')
     misc_group.add_argument('--tempdir', action="store",
@@ -232,9 +234,6 @@ def main(sysargs = sys.argv[1:]):
             args.ref_char = None
         elif "ref_char" in args and not args.ref_char:
             args.ref_char = '-'
-
-        if "append_genotypes" in args and args.append_genotypes and not args.output_counts:
-            args.output_counts = True
 
     """
     Exit with help menu if no args supplied

--- a/scorpio/scripts/type_constellations.py
+++ b/scorpio/scripts/type_constellations.py
@@ -378,6 +378,22 @@ def parse_variants_in(refseq, features_dict, variants_file, constellation_names=
 
     return name, variant_list, rule_dict, mrca_lineage, incompatible_lineage_calls
 
+
+def parse_mutations_in(mutations_file):
+    print("\nParsing mutations file %s" % mutations_file)
+
+    mutations_list = []
+    with open("%s" % mutations_file, "r") as f:
+        for line in f:
+            l = line.split("#")[0].strip().split(',')[0]  # remove comments from the line and assume in first column
+            if len(l) > 0:  # skip blank lines (or comment only lines)
+                if l.startswith('id'):
+                    continue
+                mutations_list.append(l)
+    print("Found %d mutations" % len(mutations_list))
+    return mutations_list
+
+
 def parse_mutations(refseq, features_dict, mutations_list):
     """
     Parse the mutations specified on command line and make a mutations constellation for them
@@ -589,6 +605,13 @@ def type_constellations(in_fasta, list_constellation_files, constellation_names,
         else:
             print("Warning: %s is not a valid constellation file - ignoring" % constellation_file)
     if mutations_list:
+        new_mutations_list = []
+        for entry in mutations_list:
+            if '.' in entry:
+                new_mutations_list.extend(parse_mutations_in(entry))  # this is a file
+            else:
+                new_mutations_list.append(entry)
+        mutations_list = new_mutations_list
         mutation_variants = parse_mutations(reference_seq, features_dict, mutations_list)
         if len(constellation_dict) == 1:
             constellation = list(constellation_dict)[0]
@@ -678,6 +701,13 @@ def classify_constellations(in_fasta, list_constellation_files, constellation_na
             print("Warning: %s is not a valid constellation file - ignoring" % constellation_file)
 
     if mutations_list:
+        new_mutations_list = []
+        for entry in mutations_list:
+            if '.' in entry:
+                new_mutations_list.extend(parse_mutations_in(entry)) # this is a file
+            else:
+                new_mutations_list.append(entry)
+        mutations_list = new_mutations_list
         mutation_variants = parse_mutations(reference_seq, features_dict, mutations_list)
 
     variants_out = open(out_csv, "w")

--- a/scorpio/scripts/type_constellations.py
+++ b/scorpio/scripts/type_constellations.py
@@ -573,14 +573,19 @@ def type_constellations(in_fasta, list_constellation_files, constellation_names,
         else:
             print("Warning: %s is not a valid constellation file - ignoring" % constellation_file)
 
-    variants_out = open(out_csv, "w")
-    variants_out.write("query,%s\n" % ",".join(list(constellation_dict.keys())))
+    variants_out = None
+    if len(constellation_dict) > 1 or not output_counts:
+        variants_out = open(out_csv, "w")
+        variants_out.write("query,%s\n" % ",".join(list(constellation_dict.keys())))
 
     counts_out = {}
     if output_counts:
         for constellation in constellation_dict:
             clean_name = re.sub("[^a-zA-Z0-9_\-.]", "_", constellation)
-            counts_out[constellation] = open("%s.%s_counts.csv" % (out_csv.replace(".csv", ""), clean_name), "w")
+            if len(constellation_dict) == 1:
+                counts_out[constellation] = open(out_csv, "w")
+            else:
+                counts_out[constellation] = open("%s.%s_counts.csv" % (out_csv.replace(".csv", ""), clean_name), "w")
             columns = ["query,ref_count,alt_count,ambig_count,other_count,support,conflict"]
             if append_genotypes:
                 columns.extend([var["name"] for var in constellation_dict[constellation]])
@@ -603,10 +608,11 @@ def type_constellations(in_fasta, list_constellation_files, constellation_names,
                         columns.extend(barcode_list)
                     counts_out[constellation].write("%s\n" % ','.join(columns))
                 out_list.append(''.join(barcode_list))
+            if variants_out:
+                variants_out.write("%s\n" % ",".join(out_list))
 
-            variants_out.write("%s\n" % ",".join(out_list))
-
-    variants_out.close()
+    if variants_out:
+        variants_out.close()
     for constellation in counts_out:
         if counts_out[constellation]:
             counts_out[constellation].close()

--- a/scorpio/scripts/type_constellations.py
+++ b/scorpio/scripts/type_constellations.py
@@ -613,7 +613,7 @@ def type_constellations(in_fasta, list_constellation_files, constellation_names,
                 new_mutations_list.append(entry)
         mutations_list = new_mutations_list
         mutation_variants = parse_mutations(reference_seq, features_dict, mutations_list)
-        if len(constellation_dict) == 1:
+        if len(constellation_dict) == 1 and "mutations" not in constellation_dict:
             constellation = list(constellation_dict)[0]
             new_constellation = "%s+%s" %(constellation, '|'.join(mutations_list))
             constellation_dict[new_constellation] = constellation_dict[constellation] + mutation_variants

--- a/scorpio/scripts/type_constellations.py
+++ b/scorpio/scripts/type_constellations.py
@@ -649,7 +649,7 @@ def type_constellations(in_fasta, list_constellation_files, constellation_names,
 
 
 def classify_constellations(in_fasta, list_constellation_files, constellation_names, out_csv, reference_json,
-                            output_counts=False, call_all=False, long=False, label=None, list_incompatible=False):
+                            output_counts=False, call_all=False, long=False, label=None, list_incompatible=False, mutations_list=None):
 
     reference_seq, features_dict = load_feature_coordinates(reference_json)
 
@@ -677,12 +677,17 @@ def classify_constellations(in_fasta, list_constellation_files, constellation_na
         else:
             print("Warning: %s is not a valid constellation file - ignoring" % constellation_file)
 
+    if mutations_list:
+        mutation_variants = parse_mutations(reference_seq, features_dict, mutations_list)
+
     variants_out = open(out_csv, "w")
     columns = ["query","constellations","mrca_lineage"]
     if list_incompatible:
         columns.append("incompatible_lineages")
     if long and not call_all:
         columns.extend(["ref_count","alt_count","ambig_count","other_count","rule_count","support","conflict"])
+    if mutations_list:
+        columns.extend(mutations_list)
     variants_out.write("%s\n" %",".join(columns))
 
     counts_out = {}
@@ -741,6 +746,10 @@ def classify_constellations(in_fasta, list_constellation_files, constellation_na
                                                              best_counts['support'], best_counts['conflict']))
             elif long and not call_all:
                 out_entries.append(",,,,,,")
+
+            if mutations_list:
+                barcode_list, counts = generate_barcode(record.seq, mutation_variants)
+                out_entries.extend(barcode_list)
 
             variants_out.write("%s\n" % ",".join(out_entries))
 

--- a/scorpio/scripts/yml_to_json.py
+++ b/scorpio/scripts/yml_to_json.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+import csv
+from Bio import SeqIO
+from Bio.Seq import Seq
+import argparse
+import sys
+import json
+import re
+import yaml
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="""Convert PHE yml to json.""",
+                                     formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument('--yml', help='in yaml')
+    args = parser.parse_args()
+
+    return args
+
+def parse_vars(var_dict):
+    sites = []
+    for var in var_dict:
+        if "amino-acid-change" in var:
+            sites.append("%s:%s" % (var["gene"], var["amino-acid-change"]))
+        elif var["type"] == "deletion":
+            sites.append("del:%i:%i" % (var["one-based-reference-position"],
+                                        len(var["reference-base"]) - len(var["variant-base"])))
+        elif var["type"] == "insertion":
+            sites.append("nuc:%i+%s" % (var["one-based-reference-position"], var["variant-base"][1:]))
+        elif var["type"] == "SNP":
+            sites.append("nuc:%s%i%s" % (var["reference-base"], var["one-based-reference-position"],
+                                         var["variant-base"]))
+        else:
+            print("Could not translate variant", var)
+    return sites
+
+
+def parse_rules(old_rules, sites):
+    rules = {}
+    rules["min_alt"] = old_rules["mutations-required"]
+    rules["max_ref"] = len(sites) - old_rules["allowed-wildtype"]
+    if "variants" in old_rules:
+        rule_sites = parse_vars(old_rules["variants"])
+        for site in rule_sites:
+            rules["site"] = "alt"
+            if site not in yml["sites"]:
+                sites.append(site)
+    return rules
+
+
+def convert(yml_file):
+    out_dict = {}
+    with open(yml_file, 'r') as stream:
+        try:
+            yml = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+    pango_lineage = yml["belongs-to-lineage"][0]["PANGO"]
+    out_dict["label"] = "c%s" %pango_lineage
+    out_dict["description"] = yml["description"]
+    del yml["description"]
+
+    out_dict["sources"] = yml["information-sources"]
+    if out_dict["sources"] == [""]:
+        out_dict["sources"] = []
+    del yml["information-sources"]
+
+    out_dict["type"] = "variant"
+    out_dict["variant"] = {
+
+    }
+    out_dict["tags"] = [
+        pango_lineage
+    ]
+
+    for key in ["phe-label", "who-label"]:
+        if key in yml:
+            out_dict["variant"][key] = yml[key]
+            out_dict["tags"].append(yml[key])
+            del yml[key]
+    for key in["unique-id"]:
+        if key in yml:
+            out_dict["tags"].append(yml[key])
+            del yml[key]
+    for key in ["alternate-names"]:
+        if key in yml:
+            out_dict["tags"].extend(yml[key])
+            del yml[key]
+    out_dict["variant"]["pango-lineages"] = [pango_lineage]
+    out_dict["variant"]["representative-genome"] = ""
+    for key in yml["belongs-to-lineage"][0]:
+        if key != "PANGO":
+            out_dict["tags"].append(yml[key])
+    del yml["belongs-to-lineage"]
+
+    sites = parse_vars(yml["variants"])
+    del yml["variants"]
+    out_dict["sites"] = sites
+
+    if "probable" in yml["calling-definition"]:
+        rules = parse_rules(yml["calling-definition"]["probable"], sites)
+        del yml["calling-definition"]
+        out_dict["rules"] = rules
+    elif "confirmed" in yml["calling-definition"]:
+        rules = parse_rules(yml["calling-definition"]["confirmed"], sites)
+        del yml["calling-definition"]
+        out_dict["rules"] = rules
+    else:
+        print("Could not parse rules from", yml["calling-definition"])
+
+    for key in yml:
+        if yml[key] not in [None, "", []]:
+            print("Ignored key:", key)
+
+    with open("%s.json" %out_dict["label"], 'w') as outfile:
+        json.dump(out_dict, outfile, indent=4)
+
+def main():
+    args = parse_args()
+    convert(args.yml)
+
+if __name__ == '__main__':
+    main()

--- a/scorpio/subcommands/classify.py
+++ b/scorpio/subcommands/classify.py
@@ -13,4 +13,5 @@ def run(options):
                         options.call_all,
                         options.long,
                         options.label,
-                        options.list_incompatible)
+                        options.list_incompatible,
+                        options.mutations)

--- a/scorpio/subcommands/haplotype.py
+++ b/scorpio/subcommands/haplotype.py
@@ -12,4 +12,5 @@ def run(options):
                         options.ref_char,
                         options.output_counts,
                         options.label,
-                        options.append_genotypes)
+                        options.append_genotypes,
+                        options.mutations)


### PR DESCRIPTION
Addresses #22 and #6
`scorpio haplotype` and `scorpio classify` now accept a list of mutations or mutations files (txt or csv with ids in first column with header id or no header)
These additional mutations are typed and if `--append-genotypes` is used, a column per variant is output in the relative files
Requires constellations `data/mutations.csv` to be renamed to avoid conflicts (although the worst that happens with old scorpio is you get an extra 300 mutations typed)