### PR TITLE
Dev

### DIFF
--- a/scorpio/__init__.py
+++ b/scorpio/__init__.py
@@ -1,2 +1,2 @@
 _program = "scorpio"
-__version__ = "0.3.8"
+__version__ = "0.3.9"

--- a/scorpio/__main__.py
+++ b/scorpio/__main__.py
@@ -55,6 +55,7 @@ def main(sysargs = sys.argv[1:]):
                             help="Specify where you want the temporary stuff to go Default: $TMPDIR")
     misc_group.add_argument("--no-temp", action="store_true", help="Output all intermediate files")
     misc_group.add_argument("--verbose", action="store_true", help="Print lots of stuff to screen")
+    misc_group.add_argument("--dry-run", dest="dry_run", action="store_true", help="Quit after checking constellations and variants are AOK")
     misc_group.add_argument('-t', '--threads', action='store', dest="threads", type=int, help="Number of threads")
 
     # _______________________________  classify  __________________________________#

--- a/scorpio/subcommands/classify.py
+++ b/scorpio/subcommands/classify.py
@@ -5,13 +5,14 @@ from scorpio.scripts.type_constellations import *
 
 def run(options):
     classify_constellations(options.input,
-                        options.constellations,
-                        options.names,
-                        options.output,
-                        options.reference_json,
-                        options.output_counts,
-                        options.call_all,
-                        options.long,
-                        options.label,
-                        options.list_incompatible,
-                        options.mutations)
+                            options.constellations,
+                            options.names,
+                            options.output,
+                            options.reference_json,
+                            options.output_counts,
+                            options.call_all,
+                            options.long,
+                            options.label,
+                            options.list_incompatible,
+                            options.mutations,
+                            options.dry_run)

--- a/scorpio/subcommands/haplotype.py
+++ b/scorpio/subcommands/haplotype.py
@@ -13,4 +13,5 @@ def run(options):
                         options.output_counts,
                         options.label,
                         options.append_genotypes,
-                        options.mutations)
+                        options.mutations,
+                        options.dry_run)


### PR DESCRIPTION
Add `--dry-run` option which runs `classify` and `haplotype` only up to the point where constellation files have been parsed.
Fix bug in `haplotype` where 2 open file handles were trying to write the same data to the same file
Exit rather than ignore if mutations specified with `--mutations` are not in an acceptable format